### PR TITLE
Look before you leap.

### DIFF
--- a/bugzilla2fedmsg.py
+++ b/bugzilla2fedmsg.py
@@ -6,7 +6,6 @@ Authors:    Ralph Bean <rbean@redhat.com>
 """
 
 import datetime
-import Queue as queue  # stdlib
 import socket
 import time
 


### PR DESCRIPTION
It used to be that bugzilla's messaging plugin sent only a timestamp and
the bug_id of the bug that changed.  We had to call back to RHBZ over the
xmlrpc API right off the bat in order to figure out if this was a Fedora or
Fedora EPEL bug that we cared about.

As of [this ticket](https://bugzilla.redhat.com/show_bug.cgi?id=1248259),
we are now able to check the product supplied in the original message, so
that we can reduce the strain we put on RHBZ's xmlrpc api.