### PR TITLE
Update for bz5.

### DIFF
--- a/development.ini.example
+++ b/development.ini.example
@@ -7,11 +7,6 @@ bugzilla.products = Fedora, Fedora EPEL
 # If you have 8 worker threads you *also* need 8 fedmsg endpoints in fedmsg.d/
 bugzilla.num_workers = 2
 
-## These are credentials used to log in to bugzilla
-bugzilla.url = https://bugzilla.redhat.com
-#bugzilla.username = foo@foo.com
-#bugzilla.password = bunbunbun
-
 # Stomp broker configuration.
 
 ## Single broker
@@ -25,3 +20,5 @@ stomp_user = username
 stomp_pass = password
 stomp_ssl_crt = /path/to/an/optional.crt
 stomp_ssl_key = /path/to/an/optional.key
+
+stomp_queue = /queue/Consumer.fedora.A-UNIQUE-SHARED-QUEUE-ID.VirtualTopic.eng.bugzilla.>


### PR DESCRIPTION
Notably, the message from the UMB contains more information now, so
we don't need to query bz via xmlrpc to get the data for the message.