### PR TITLE
More adaptations and improvements related to Bugzilla 5 and fedora-messaging port

### DIFF
--- a/bugzilla2fedmsg/relay.py
+++ b/bugzilla2fedmsg/relay.py
@@ -57,15 +57,19 @@ class MessageRelay:
         event = convert_datetimes(event)
 
         # backwards compat for bz5
-        if bug["assigned_to"]:
+        if bug.get("assigned_to", {}).get("login"):
             bug["assigned_to"] = bug["assigned_to"]["login"]
-        if bug["component"]:
+        if bug.get("component", {}).get("name"):
             bug["component"] = bug["component"]["name"]
+        if bug.get("product", {}).get("name"):
+            bug["product"] = bug["product"]["name"]
         bug["cc"] = bug.get("cc", [])
-        if bug["reporter"]:
+        if bug.get("reporter", {}).get("login"):
             bug["creator"] = bug["reporter"]["login"]
-        if bug["operating_system"]:
+        if bug.get("operating_system"):
             bug["op_sys"] = bug["operating_system"]
+        if not bug.get("weburl"):
+            bug["weburl"] = "https://bugzilla.redhat.com/show_bug.cgi?id=%s" % bug['id']
         event["who"] = event["user"]["login"]
         event["changes"] = event.get("changes", [])
         for change in event["changes"]:

--- a/bugzilla2fedmsg/relay.py
+++ b/bugzilla2fedmsg/relay.py
@@ -10,54 +10,6 @@ from .utils import convert_datetimes
 
 LOGGER = logging.getLogger(__name__)
 
-# These are bug fields we're going to try and pass on to fedora-messaging.
-BUG_FIELDS = [
-    "alias",
-    "assigned_to",
-    # 'attachments',  # These can contain binary things we don't want to send.
-    "blocks",
-    "cc",
-    "classification",
-    "component",
-    "components",
-    "creation_time",
-    "depends_on",
-    "description",
-    "docs_contact",
-    "estimated_time",
-    "external_bugs",
-    "fixed_in",
-    "flags",
-    "groups",
-    "id",
-    "is_cc_accessible",
-    "is_confirmed",
-    "is_creator_accessible",
-    "is_open",
-    "keywords",
-    "last_change_time",
-    "operating_system",
-    "platform",
-    "priority",
-    "product",
-    "qa_contact",
-    "actual_time",
-    "remaining_time",
-    "reporter",
-    "resolution",
-    "see_also",
-    "severity",
-    "status",
-    "summary",
-    "target_milestone",
-    "target_release",
-    "url",
-    "version",
-    "versions",
-    "weburl",
-    "whiteboard",
-]
-
 
 class MessageRelay:
     def __init__(self, config):
@@ -98,9 +50,6 @@ class MessageRelay:
             LOGGER.debug("DROP: %r not in %r" % (product_name, self._allowed_products))
             return
 
-        LOGGER.debug("Organizing metadata for #%s" % bug["id"])
-        bug = dict([(attr, bug.get(attr, None)) for attr in BUG_FIELDS])
-
         body["timestamp"] = datetime.datetime.fromtimestamp(
             int(headers["timestamp"]) / 1000.0, pytz.UTC
         )
@@ -112,7 +61,7 @@ class MessageRelay:
             bug["assigned_to"] = bug["assigned_to"]["login"]
         if bug["component"]:
             bug["component"] = bug["component"]["name"]
-        bug["cc"] = bug["cc"] or []
+        bug["cc"] = bug.get("cc", [])
         if bug["reporter"]:
             bug["creator"] = bug["reporter"]["login"]
         if bug["operating_system"]:

--- a/bugzilla2fedmsg/utils.py
+++ b/bugzilla2fedmsg/utils.py
@@ -15,7 +15,8 @@ LOGGER = logging.getLogger(__name__)
 
 def convert_datetimes(obj):
     """ Recursively convert the ISO-8601ish date/time strings we get
-    from stomp to stdlib datetimes.
+    from stomp to epoch integers (because this is what fedmsg used to
+    emit when we sent it datetime instances).
     """
 
     if isinstance(obj, list):
@@ -34,6 +35,6 @@ def convert_datetimes(obj):
             # UI it does indeed seem to be.
             ourdate = datetime.datetime.strptime(obj, "%Y-%m-%dT%H:%M:%S")
             ourdate = ourdate.replace(tzinfo=pytz.UTC)
-            return ourdate
+            return ourdate.timestamp()
         except (ValueError, TypeError):
             return obj

--- a/fedora-messaging.toml.example
+++ b/fedora-messaging.toml.example
@@ -32,7 +32,11 @@ certfile = "/my/client/cert.pem"
     prefetch_size = 100
 
     [consumer_config.bugzilla]
+    # Products to relay messages for - messages for bugs files against
+    # other products will be ignored
     products = ["Fedora", "Fedora EPEL"]
+    # Whether to modify messages to look more like Bugzilla 4 ones did
+    bz4compat = true
 
 
 [client_properties]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,673 @@
+# -*- coding: utf-8 -*-
+""" Test fixtures for bugzilla2fedmsg.relay.
+
+Authors:    Adam Williamson <awilliam@redhat.com>
+
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def bug_create_message(request):
+    """Sample upstream bug.create message."""
+    return {
+      "username": None,
+      "source_name": "datanommer",
+      "certificate": None,
+      "i": 0,
+      "timestamp": 1555619246.0,
+      "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:8852",
+      "crypto": None,
+      "topic": "/topic/VirtualTopic.eng.bugzilla.bug.create",
+      "headers": {
+        "content-length": "1498",
+        "expires": "1555705646848",
+        "esbMessageType": "bugzillaNotification",
+        "timestamp": "1555619246848",
+        "original-destination": "/topic/VirtualTopic.eng.bugzilla.bug.create",
+        "destination": "/topic/VirtualTopic.eng.bugzilla.bug.create",
+        "correlation-id": "06ed3815-4596-49a0-a5a5-1d5b6b7bf01a",
+        "priority": "4",
+        "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.bug.create",
+        "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:8852",
+        "esbSourceSystem": "bugzilla"
+      },
+      "signature": None,
+      "source_version": "0.9.1",
+      "body": {
+        "bug": {
+          "whiteboard": "abrt_hash:ca3702e55e5d4a4f3057d7a62ad195583a2b9a409990f275a36c87373bd77445;",
+          "classification": "Fedora",
+          "cf_story_points": "",
+          "creation_time": "2019-04-18T20:27:01",
+          "target_milestone": None,
+          "keywords": [],
+          "summary": "SELinux is preventing touch from 'write' accesses on the file /var/log/shorewall-init.log.",
+          "cf_ovirt_team": "",
+          "cf_release_notes": "",
+          "cf_cloudforms_team": "",
+          "cf_type": "",
+          "cf_fixed_in": "",
+          "cf_atomic": "",
+          "id": 1701391,
+          "priority": "unspecified",
+          "platform": "x86_64",
+          "version": {
+            "id": 5586,
+            "name": "29"
+          },
+          "cf_regression_status": "",
+          "cf_environment": "",
+          "status": {
+            "id": 1,
+            "name": "NEW"
+          },
+          "product": {
+            "id": 49,
+            "name": "Fedora"
+          },
+          "qa_contact": {
+            "login": "extras-qa@fedoraproject.org",
+            "id": 171387,
+            "real_name": "Fedora Extras Quality Assurance"
+          },
+          "reporter": {
+            "login": "dgunchev@gmail.com",
+            "id": 156190,
+            "real_name": "Doncho Gunchev"
+          },
+          "component": {
+            "id": 17100,
+            "name": "selinux-policy"
+          },
+          "cf_category": "",
+          "cf_doc_type": "",
+          "cf_documentation_action": "",
+          "cf_clone_of": "",
+          "is_private": False,
+          "severity": "unspecified",
+          "operating_system": "Unspecified",
+          "url": "",
+          "last_change_time": "2019-04-18T20:27:01",
+          "cf_crm": "",
+          "cf_last_closed": None,
+          "alias": [],
+          "flags": [],
+          "assigned_to": {
+            "login": "lvrabec@redhat.com",
+            "id": 316673,
+            "real_name": "Lukas Vrabec"
+          },
+          "resolution": "",
+          "cf_mount_type": ""
+        },
+        "event": {
+          "target": "bug",
+          "change_set": "6792.1555619221.41171",
+          "routing_key": "bug.create",
+          "bug_id": 1701391,
+          "user": {
+            "login": "dgunchev@gmail.com",
+            "id": 156190,
+            "real_name": "Doncho Gunchev"
+          },
+          "time": "2019-04-18T20:27:01",
+          "action": "create"
+        }
+      }
+    }
+
+
+@pytest.fixture(scope="function")
+def bug_modify_message(request):
+    """Sample upstream bug.modify message."""
+    return {
+      "username": None,
+      "source_name": "datanommer",
+      "certificate": None,
+      "i": 0,
+      "timestamp": 1555607535.0,
+      "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:7266",
+      "crypto": None,
+      "topic": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
+      "headers": {
+        "content-length": "1556",
+        "expires": "1555693935155",
+        "esbMessageType": "bugzillaNotification",
+        "timestamp": "1555607535155",
+        "original-destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
+        "destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
+        "correlation-id": "b18f93bb-8a69-4651-8f6b-48a6c323a620",
+        "priority": "4",
+        "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.bug.modify",
+        "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:7266",
+        "esbSourceSystem": "bugzilla"
+      },
+      "signature": None,
+      "source_version": "0.9.1",
+      "body": {
+        "bug": {
+          "whiteboard": "",
+          "classification": "Fedora",
+          "cf_story_points": "",
+          "creation_time": "2019-04-12T05:49:43",
+          "target_milestone": None,
+          "keywords": [
+            "FutureFeature",
+            "Triaged"
+          ],
+          "summary": "python-pyramid-1.10.4 is available",
+          "cf_ovirt_team": "",
+          "cf_release_notes": "",
+          "cf_cloudforms_team": "",
+          "cf_type": "",
+          "cf_fixed_in": "",
+          "cf_atomic": "",
+          "id": 1699203,
+          "priority": "unspecified",
+          "platform": "Unspecified",
+          "version": {
+            "id": 495,
+            "name": "rawhide"
+          },
+          "cf_regression_status": "",
+          "cf_environment": "",
+          "status": {
+            "id": 1,
+            "name": "NEW"
+          },
+          "product": {
+            "id": 49,
+            "name": "Fedora"
+          },
+          "qa_contact": {
+            "login": "extras-qa@fedoraproject.org",
+            "id": 171387,
+            "real_name": "Fedora Extras Quality Assurance"
+          },
+          "reporter": {
+            "login": "upstream-release-monitoring@fedoraproject.org",
+            "id": 282165,
+            "real_name": "Upstream Release Monitoring"
+          },
+          "component": {
+            "id": 102174,
+            "name": "python-pyramid"
+          },
+          "cf_category": "",
+          "cf_doc_type": "Enhancement",
+          "cf_documentation_action": "",
+          "cf_clone_of": "",
+          "is_private": False,
+          "severity": "unspecified",
+          "operating_system": "Unspecified",
+          "url": "",
+          "last_change_time": "2019-04-17T19:11:00",
+          "cf_crm": "",
+          "cf_last_closed": None,
+          "alias": [],
+          "flags": [],
+          "assigned_to": {
+            "login": "infra-sig@lists.fedoraproject.org",
+            "id": 370504,
+            "real_name": "Fedora Infrastructure SIG"
+          },
+          "resolution": "",
+          "cf_mount_type": ""
+        },
+        "event": {
+          "target": "bug",
+          "change_set": "62607.1555607510.78558",
+          "routing_key": "bug.modify",
+          "bug_id": 1699203,
+          "user": {
+            "login": "mhroncok@redhat.com",
+            "id": 310625,
+            "real_name": "Miro Hron\u010dok"
+          },
+          "time": "2019-04-18T17:11:51",
+          "action": "modify",
+          "changes": [
+            {
+              "field": "cc",
+              "removed": "",
+              "added": "mhroncok@redhat.com"
+            }
+          ]
+        }
+      }
+    }
+
+
+@pytest.fixture(scope="function")
+def comment_create_message(request):
+    """Sample upstream comment.create message."""
+    return {
+      "username": None,
+      "source_name": "datanommer",
+      "certificate": None,
+      "i": 0,
+      "timestamp": 1555602948.0,
+      "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:6693",
+      "crypto": None,
+      "topic": "/topic/VirtualTopic.eng.bugzilla.comment.create",
+      "headers": {
+        "content-length": "1938",
+        "expires": "1555689348470",
+        "esbMessageType": "bugzillaNotification",
+        "timestamp": "1555602948470",
+        "original-destination": "/topic/VirtualTopic.eng.bugzilla.comment.create",
+        "destination": "/topic/VirtualTopic.eng.bugzilla.comment.create",
+        "correlation-id": "93ab27cf-fada-4e6a-aef5-db7af28b2b71",
+        "priority": "4",
+        "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.comment.create",
+        "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:6693",
+        "esbSourceSystem": "bugzilla"
+      },
+      "signature": None,
+      "source_version": "0.9.1",
+      "body": {
+        "comment": {
+          "body": "qa09 and qa14 have 8 560 GB SAS drives which are RAID-6 together. \n\nThe systems we get from IBM come through a special contract which in the past required the system to be sent back to add hardware to it. When we added drives it also caused problems because the system didn't match the contract when we returned it. I am checking with IBM on the wearabouts for the systems.",
+          "creation_time": "2019-04-18T15:55:38",
+          "number": 8,
+          "id": 1691487,
+          "bug": {
+            "whiteboard": "",
+            "classification": "Fedora",
+            "cf_story_points": "",
+            "creation_time": "2019-03-21T17:49:49",
+            "target_milestone": None,
+            "keywords": [],
+            "summary": "openQA transient test failure as duplicated first character just after a snapshot",
+            "cf_ovirt_team": "",
+            "cf_release_notes": "",
+            "cf_cloudforms_team": "",
+            "cf_type": "Bug",
+            "cf_fixed_in": "",
+            "cf_atomic": "",
+            "id": 1691487,
+            "priority": "unspecified",
+            "platform": "ppc64le",
+            "version": {
+              "id": 5713,
+              "name": "30"
+            },
+            "cf_regression_status": "",
+            "cf_environment": "",
+            "status": {
+              "id": 1,
+              "name": "NEW"
+            },
+            "product": {
+              "id": 49,
+              "name": "Fedora"
+            },
+            "qa_contact": {
+              "login": "extras-qa@fedoraproject.org",
+              "id": 171387,
+              "real_name": "Fedora Extras Quality Assurance"
+            },
+            "reporter": {
+              "login": "normand@linux.vnet.ibm.com",
+              "id": 364546,
+              "real_name": "Michel Normand"
+            },
+            "component": {
+              "id": 145692,
+              "name": "openqa"
+            },
+            "cf_category": "",
+            "cf_doc_type": "If docs needed, set a value",
+            "cf_documentation_action": "",
+            "cf_clone_of": "",
+            "is_private": False,
+            "severity": "unspecified",
+            "operating_system": "Unspecified",
+            "url": "",
+            "last_change_time": "2019-04-18T15:21:42",
+            "cf_crm": "",
+            "cf_last_closed": None,
+            "alias": [],
+            "flags": [],
+            "assigned_to": {
+              "login": "awilliam@redhat.com",
+              "id": 273090,
+              "real_name": "Adam Williamson"
+            },
+            "resolution": "",
+            "cf_mount_type": ""
+          },
+          "is_private": False
+        },
+        "event": {
+          "target": "comment",
+          "change_set": "86288.1555602938.43406",
+          "routing_key": "comment.create",
+          "bug_id": 1691487,
+          "user": {
+            "login": "smooge@redhat.com",
+            "id": 12,
+            "real_name": "Stephen John Smoogen"
+          },
+          "time": "2019-04-18T15:55:38",
+          "action": "create"
+        }
+      }
+    }
+
+
+@pytest.fixture(scope="function")
+def attachment_create_message(request):
+    """Sample upstream attachment.create message."""
+    return {
+      "username": None,
+      "source_name": "datanommer",
+      "certificate": None,
+      "i": 0,
+      "timestamp": 1555610522.0,
+      "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:7668",
+      "crypto": None,
+      "topic": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
+      "headers": {
+        "content-length": "1883",
+        "expires": "1555696922855",
+        "esbMessageType": "bugzillaNotification",
+        "timestamp": "1555610522855",
+        "original-destination": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
+        "destination": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
+        "correlation-id": "861b24d9-bada-472a-8017-a06bff301595",
+        "priority": "4",
+        "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.attachment.create",
+        "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:7668",
+        "esbSourceSystem": "bugzilla"
+      },
+      "signature": None,
+      "source_version": "0.9.1",
+      "body": {
+        "attachment": {
+          "description": "File: var_log_messages",
+          "file_name": "var_log_messages",
+          "is_patch": False,
+          "creation_time": "2019-04-18T18:01:51",
+          "id": 1556193,
+          "flags": [],
+          "last_change_time": "2019-04-18T18:01:51",
+          "content_type": "text/plain",
+          "is_obsolete": False,
+          "bug": {
+            "whiteboard": "abrt_hash:9045fad863095a5d3f3b387af2b95f43b3482a1d;VARIANT_ID=workstation;",
+            "classification": "Fedora",
+            "cf_story_points": "",
+            "creation_time": "2019-04-18T18:01:33",
+            "target_milestone": None,
+            "keywords": [],
+            "summary": "[abrt] gnome-software: gtk_widget_unparent(): gnome-software killed by SIGSEGV",
+            "cf_ovirt_team": "",
+            "cf_release_notes": "",
+            "cf_cloudforms_team": "",
+            "cf_type": "",
+            "cf_fixed_in": "",
+            "cf_atomic": "",
+            "id": 1701353,
+            "priority": "unspecified",
+            "platform": "x86_64",
+            "version": {
+              "id": 5713,
+              "name": "30"
+            },
+            "cf_regression_status": "",
+            "cf_environment": "",
+            "status": {
+              "id": 1,
+              "name": "NEW"
+            },
+            "product": {
+              "id": 49,
+              "name": "Fedora"
+            },
+            "qa_contact": {
+              "login": "extras-qa@fedoraproject.org",
+              "id": 171387,
+              "real_name": "Fedora Extras Quality Assurance"
+            },
+            "reporter": {
+              "login": "peter@sonniger-tag.eu",
+              "id": 361290,
+              "real_name": "Peter"
+            },
+            "component": {
+              "id": 126541,
+              "name": "gnome-software"
+            },
+            "cf_category": "",
+            "cf_doc_type": "If docs needed, set a value",
+            "cf_documentation_action": "",
+            "cf_clone_of": "",
+            "is_private": False,
+            "severity": "unspecified",
+            "operating_system": "Unspecified",
+            "url": "https://retrace.fedoraproject.org/faf/reports/bthash/f4ca1e58d66fb046d6d1d1b18a84dd779ad34624",
+            "last_change_time": "2019-04-18T18:01:50",
+            "cf_crm": "",
+            "cf_last_closed": None,
+            "alias": [],
+            "flags": [],
+            "assigned_to": {
+              "login": "rhughes@redhat.com",
+              "id": 213548,
+              "real_name": "Richard Hughes"
+            },
+            "resolution": "",
+            "cf_mount_type": ""
+          },
+          "is_private": False
+        },
+        "event": {
+          "target": "attachment",
+          "change_set": "78355.1555610511.09385",
+          "routing_key": "attachment.create",
+          "bug_id": 1701353,
+          "user": {
+            "login": "peter@sonniger-tag.eu",
+            "id": 361290,
+            "real_name": "Peter"
+          },
+          "time": "2019-04-18T18:01:51",
+          "action": "create"
+        }
+      }
+    }
+
+
+@pytest.fixture(scope="function")
+def private_message(request):
+    """Sample upstream private message."""
+    return {
+      "username": None,
+      "source_name": "datanommer",
+      "certificate": None,
+      "i": 0,
+      "timestamp": 1555617948.0,
+      "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:8683",
+      "crypto": None,
+      "topic": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
+      "headers": {
+        "content-length": "391",
+        "expires": "1555704348944",
+        "esbMessageType": "bugzillaNotification",
+        "timestamp": "1555617948944",
+        "original-destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
+        "destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
+        "correlation-id": "1566656e-4163-4d02-856c-9a888ce482d8",
+        "priority": "4",
+        "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.bug.modify",
+        "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:8683",
+        "esbSourceSystem": "bugzilla"
+      },
+      "signature": None,
+      "source_version": "0.9.1",
+      "body": {
+        "event": {
+          "target": "bug",
+          "change_set": "123367.1555617940.83869",
+          "routing_key": "bug.modify",
+          "bug_id": 1493146,
+          "user": {
+            "login": "bob@roberts.com",
+            "id": 199080,
+            "real_name": "Bob Roberts"
+          },
+          "time": "2019-04-18T20:05:41",
+          "action": "modify",
+          "changes": [
+            {
+              "field": "cc",
+              "removed": "",
+              "added": "bob@roberts.com, rob@boberts.com"
+            },
+            {
+              "field": "flag.needinfo",
+              "removed": "",
+              "added": "? (rob@boberts.com)"
+            }
+          ]
+        }
+      }
+    }
+
+
+@pytest.fixture(scope="function")
+def other_product_message(request):
+    """Sample upstream message for another product."""
+    return {
+      "username": None,
+      "source_name": "datanommer",
+      "certificate": None,
+      "i": 0,
+      "timestamp": 1555602888.0,
+      "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:6687",
+      "crypto": None,
+      "topic": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
+      "headers": {
+        "content-length": "1744",
+        "expires": "1555689288212",
+        "esbMessageType": "bugzillaNotification",
+        "timestamp": "1555602888212",
+        "original-destination": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
+        "destination": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
+        "correlation-id": "6be413f1-5c44-4598-bca5-c0b07e5a4208",
+        "priority": "4",
+        "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.attachment.create",
+        "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:6687",
+        "esbSourceSystem": "bugzilla"
+      },
+      "signature": None,
+      "source_version": "0.9.1",
+      "body": {
+        "attachment": {
+          "description": "journalctl/systemctl output",
+          "file_name": "kubelet.tgz",
+          "is_patch": False,
+          "creation_time": "2019-04-18T15:54:39",
+          "id": 1556163,
+          "flags": [],
+          "last_change_time": "2019-04-18T15:54:39",
+          "content_type": "application/gzip",
+          "is_obsolete": False,
+          "bug": {
+            "whiteboard": "",
+            "classification": "Red Hat",
+            "cf_story_points": "",
+            "creation_time": "2019-04-18T15:46:21",
+            "target_milestone": None,
+            "keywords": [],
+            "summary": "One master shows not ready out of 3 after several hours post deployment.",
+            "cf_ovirt_team": "",
+            "cf_release_notes": "",
+            "cf_cloudforms_team": "",
+            "cf_type": "Bug",
+            "cf_fixed_in": "",
+            "cf_atomic": "",
+            "id": 1701324,
+            "priority": "unspecified",
+            "platform": "Unspecified",
+            "version": {
+              "id": 5777,
+              "name": "unspecified"
+            },
+            "cf_regression_status": "",
+            "cf_environment": "",
+            "status": {
+              "id": 1,
+              "name": "NEW"
+            },
+            "product": {
+              "id": 561,
+              "name": "Kubernetes-native Infrastructure"
+            },
+            "qa_contact": {
+              "login": "achernet@redhat.com",
+              "id": 391433,
+              "real_name": "Arik Chernetsky"
+            },
+            "reporter": {
+              "login": "sasha@redhat.com",
+              "id": 309636,
+              "real_name": "Alexander Chuzhoy"
+            },
+            "component": {
+              "id": 180277,
+              "name": "Deployment"
+            },
+            "cf_category": "",
+            "cf_doc_type": "If docs needed, set a value",
+            "cf_documentation_action": "",
+            "cf_clone_of": "",
+            "is_private": False,
+            "severity": "unspecified",
+            "operating_system": "Unspecified",
+            "url": "",
+            "last_change_time": "2019-04-18T15:46:40",
+            "cf_crm": "",
+            "cf_last_closed": None,
+            "alias": [],
+            "flags": [],
+            "assigned_to": {
+              "login": "athomas@redhat.com",
+              "id": 56702,
+              "real_name": "Angus Thomas"
+            },
+            "resolution": "",
+            "cf_mount_type": ""
+          },
+          "is_private": False
+        },
+        "event": {
+          "target": "attachment",
+          "change_set": "33145.1555602879.56178",
+          "routing_key": "attachment.create",
+          "bug_id": 1701324,
+          "user": {
+            "login": "sasha@redhat.com",
+            "id": 309636,
+            "real_name": "Alexander Chuzhoy"
+          },
+          "time": "2019-04-18T15:54:39",
+          "action": "create"
+        }
+      }
+    }

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -9,661 +9,14 @@ import mock
 import bugzilla2fedmsg.relay
 import fedora_messaging.exceptions
 
-# sample public bug creation messages
-BUGCREATE = {
-  "username": None,
-  "source_name": "datanommer",
-  "certificate": None,
-  "i": 0,
-  "timestamp": 1555619246.0,
-  "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:8852",
-  "crypto": None,
-  "topic": "/topic/VirtualTopic.eng.bugzilla.bug.create",
-  "headers": {
-    "content-length": "1498",
-    "expires": "1555705646848",
-    "esbMessageType": "bugzillaNotification",
-    "timestamp": "1555619246848",
-    "original-destination": "/topic/VirtualTopic.eng.bugzilla.bug.create",
-    "destination": "/topic/VirtualTopic.eng.bugzilla.bug.create",
-    "correlation-id": "06ed3815-4596-49a0-a5a5-1d5b6b7bf01a",
-    "priority": "4",
-    "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.bug.create",
-    "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:8852",
-    "esbSourceSystem": "bugzilla"
-  },
-  "signature": None,
-  "source_version": "0.9.1",
-  "body": {
-    "bug": {
-      "whiteboard": "abrt_hash:ca3702e55e5d4a4f3057d7a62ad195583a2b9a409990f275a36c87373bd77445;",
-      "classification": "Fedora",
-      "cf_story_points": "",
-      "creation_time": "2019-04-18T20:27:01",
-      "target_milestone": None,
-      "keywords": [],
-      "summary": "SELinux is preventing touch from 'write' accesses on the file /var/log/shorewall-init.log.",
-      "cf_ovirt_team": "",
-      "cf_release_notes": "",
-      "cf_cloudforms_team": "",
-      "cf_type": "",
-      "cf_fixed_in": "",
-      "cf_atomic": "",
-      "id": 1701391,
-      "priority": "unspecified",
-      "platform": "x86_64",
-      "version": {
-        "id": 5586,
-        "name": "29"
-      },
-      "cf_regression_status": "",
-      "cf_environment": "",
-      "status": {
-        "id": 1,
-        "name": "NEW"
-      },
-      "product": {
-        "id": 49,
-        "name": "Fedora"
-      },
-      "qa_contact": {
-        "login": "extras-qa@fedoraproject.org",
-        "id": 171387,
-        "real_name": "Fedora Extras Quality Assurance"
-      },
-      "reporter": {
-        "login": "dgunchev@gmail.com",
-        "id": 156190,
-        "real_name": "Doncho Gunchev"
-      },
-      "component": {
-        "id": 17100,
-        "name": "selinux-policy"
-      },
-      "cf_category": "",
-      "cf_doc_type": "",
-      "cf_documentation_action": "",
-      "cf_clone_of": "",
-      "is_private": False,
-      "severity": "unspecified",
-      "operating_system": "Unspecified",
-      "url": "",
-      "last_change_time": "2019-04-18T20:27:01",
-      "cf_crm": "",
-      "cf_last_closed": None,
-      "alias": [],
-      "flags": [],
-      "assigned_to": {
-        "login": "lvrabec@redhat.com",
-        "id": 316673,
-        "real_name": "Lukas Vrabec"
-      },
-      "resolution": "",
-      "cf_mount_type": ""
-    },
-    "event": {
-      "target": "bug",
-      "change_set": "6792.1555619221.41171",
-      "routing_key": "bug.create",
-      "bug_id": 1701391,
-      "user": {
-        "login": "dgunchev@gmail.com",
-        "id": 156190,
-        "real_name": "Doncho Gunchev"
-      },
-      "time": "2019-04-18T20:27:01",
-      "action": "create"
-    }
-  }
-}
-
-# sample public bug modify message
-BUGMODIFY = {
-  "username": None,
-  "source_name": "datanommer",
-  "certificate": None,
-  "i": 0,
-  "timestamp": 1555607535.0,
-  "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:7266",
-  "crypto": None,
-  "topic": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
-  "headers": {
-    "content-length": "1556",
-    "expires": "1555693935155",
-    "esbMessageType": "bugzillaNotification",
-    "timestamp": "1555607535155",
-    "original-destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
-    "destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
-    "correlation-id": "b18f93bb-8a69-4651-8f6b-48a6c323a620",
-    "priority": "4",
-    "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.bug.modify",
-    "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:7266",
-    "esbSourceSystem": "bugzilla"
-  },
-  "signature": None,
-  "source_version": "0.9.1",
-  "body": {
-    "bug": {
-      "whiteboard": "",
-      "classification": "Fedora",
-      "cf_story_points": "",
-      "creation_time": "2019-04-12T05:49:43",
-      "target_milestone": None,
-      "keywords": [
-        "FutureFeature",
-        "Triaged"
-      ],
-      "summary": "python-pyramid-1.10.4 is available",
-      "cf_ovirt_team": "",
-      "cf_release_notes": "",
-      "cf_cloudforms_team": "",
-      "cf_type": "",
-      "cf_fixed_in": "",
-      "cf_atomic": "",
-      "id": 1699203,
-      "priority": "unspecified",
-      "platform": "Unspecified",
-      "version": {
-        "id": 495,
-        "name": "rawhide"
-      },
-      "cf_regression_status": "",
-      "cf_environment": "",
-      "status": {
-        "id": 1,
-        "name": "NEW"
-      },
-      "product": {
-        "id": 49,
-        "name": "Fedora"
-      },
-      "qa_contact": {
-        "login": "extras-qa@fedoraproject.org",
-        "id": 171387,
-        "real_name": "Fedora Extras Quality Assurance"
-      },
-      "reporter": {
-        "login": "upstream-release-monitoring@fedoraproject.org",
-        "id": 282165,
-        "real_name": "Upstream Release Monitoring"
-      },
-      "component": {
-        "id": 102174,
-        "name": "python-pyramid"
-      },
-      "cf_category": "",
-      "cf_doc_type": "Enhancement",
-      "cf_documentation_action": "",
-      "cf_clone_of": "",
-      "is_private": False,
-      "severity": "unspecified",
-      "operating_system": "Unspecified",
-      "url": "",
-      "last_change_time": "2019-04-17T19:11:00",
-      "cf_crm": "",
-      "cf_last_closed": None,
-      "alias": [],
-      "flags": [],
-      "assigned_to": {
-        "login": "infra-sig@lists.fedoraproject.org",
-        "id": 370504,
-        "real_name": "Fedora Infrastructure SIG"
-      },
-      "resolution": "",
-      "cf_mount_type": ""
-    },
-    "event": {
-      "target": "bug",
-      "change_set": "62607.1555607510.78558",
-      "routing_key": "bug.modify",
-      "bug_id": 1699203,
-      "user": {
-        "login": "mhroncok@redhat.com",
-        "id": 310625,
-        "real_name": "Miro Hron\u010dok"
-      },
-      "time": "2019-04-18T17:11:51",
-      "action": "modify",
-      "changes": [
-        {
-          "field": "cc",
-          "removed": "",
-          "added": "mhroncok@redhat.com"
-        }
-      ]
-    }
-  }
-}
-
-# sample public comment.create message
-COMMENTCREATE = {
-  "username": None,
-  "source_name": "datanommer",
-  "certificate": None,
-  "i": 0,
-  "timestamp": 1555602948.0,
-  "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:6693",
-  "crypto": None,
-  "topic": "/topic/VirtualTopic.eng.bugzilla.comment.create",
-  "headers": {
-    "content-length": "1938",
-    "expires": "1555689348470",
-    "esbMessageType": "bugzillaNotification",
-    "timestamp": "1555602948470",
-    "original-destination": "/topic/VirtualTopic.eng.bugzilla.comment.create",
-    "destination": "/topic/VirtualTopic.eng.bugzilla.comment.create",
-    "correlation-id": "93ab27cf-fada-4e6a-aef5-db7af28b2b71",
-    "priority": "4",
-    "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.comment.create",
-    "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:6693",
-    "esbSourceSystem": "bugzilla"
-  },
-  "signature": None,
-  "source_version": "0.9.1",
-  "body": {
-    "comment": {
-      "body": "qa09 and qa14 have 8 560 GB SAS drives which are RAID-6 together. \n\nThe systems we get from IBM come through a special contract which in the past required the system to be sent back to add hardware to it. When we added drives it also caused problems because the system didn't match the contract when we returned it. I am checking with IBM on the wearabouts for the systems.",
-      "creation_time": "2019-04-18T15:55:38",
-      "number": 8,
-      "id": 1691487,
-      "bug": {
-        "whiteboard": "",
-        "classification": "Fedora",
-        "cf_story_points": "",
-        "creation_time": "2019-03-21T17:49:49",
-        "target_milestone": None,
-        "keywords": [],
-        "summary": "openQA transient test failure as duplicated first character just after a snapshot",
-        "cf_ovirt_team": "",
-        "cf_release_notes": "",
-        "cf_cloudforms_team": "",
-        "cf_type": "Bug",
-        "cf_fixed_in": "",
-        "cf_atomic": "",
-        "id": 1691487,
-        "priority": "unspecified",
-        "platform": "ppc64le",
-        "version": {
-          "id": 5713,
-          "name": "30"
-        },
-        "cf_regression_status": "",
-        "cf_environment": "",
-        "status": {
-          "id": 1,
-          "name": "NEW"
-        },
-        "product": {
-          "id": 49,
-          "name": "Fedora"
-        },
-        "qa_contact": {
-          "login": "extras-qa@fedoraproject.org",
-          "id": 171387,
-          "real_name": "Fedora Extras Quality Assurance"
-        },
-        "reporter": {
-          "login": "normand@linux.vnet.ibm.com",
-          "id": 364546,
-          "real_name": "Michel Normand"
-        },
-        "component": {
-          "id": 145692,
-          "name": "openqa"
-        },
-        "cf_category": "",
-        "cf_doc_type": "If docs needed, set a value",
-        "cf_documentation_action": "",
-        "cf_clone_of": "",
-        "is_private": False,
-        "severity": "unspecified",
-        "operating_system": "Unspecified",
-        "url": "",
-        "last_change_time": "2019-04-18T15:21:42",
-        "cf_crm": "",
-        "cf_last_closed": None,
-        "alias": [],
-        "flags": [],
-        "assigned_to": {
-          "login": "awilliam@redhat.com",
-          "id": 273090,
-          "real_name": "Adam Williamson"
-        },
-        "resolution": "",
-        "cf_mount_type": ""
-      },
-      "is_private": False
-    },
-    "event": {
-      "target": "comment",
-      "change_set": "86288.1555602938.43406",
-      "routing_key": "comment.create",
-      "bug_id": 1691487,
-      "user": {
-        "login": "smooge@redhat.com",
-        "id": 12,
-        "real_name": "Stephen John Smoogen"
-      },
-      "time": "2019-04-18T15:55:38",
-      "action": "create"
-    }
-  }
-}
-
-# sample public attachment.create message
-ATTACHMENTCREATE = {
-  "username": None,
-  "source_name": "datanommer",
-  "certificate": None,
-  "i": 0,
-  "timestamp": 1555610522.0,
-  "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:7668",
-  "crypto": None,
-  "topic": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
-  "headers": {
-    "content-length": "1883",
-    "expires": "1555696922855",
-    "esbMessageType": "bugzillaNotification",
-    "timestamp": "1555610522855",
-    "original-destination": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
-    "destination": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
-    "correlation-id": "861b24d9-bada-472a-8017-a06bff301595",
-    "priority": "4",
-    "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.attachment.create",
-    "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:7668",
-    "esbSourceSystem": "bugzilla"
-  },
-  "signature": None,
-  "source_version": "0.9.1",
-  "body": {
-    "attachment": {
-      "description": "File: var_log_messages",
-      "file_name": "var_log_messages",
-      "is_patch": False,
-      "creation_time": "2019-04-18T18:01:51",
-      "id": 1556193,
-      "flags": [],
-      "last_change_time": "2019-04-18T18:01:51",
-      "content_type": "text/plain",
-      "is_obsolete": False,
-      "bug": {
-        "whiteboard": "abrt_hash:9045fad863095a5d3f3b387af2b95f43b3482a1d;VARIANT_ID=workstation;",
-        "classification": "Fedora",
-        "cf_story_points": "",
-        "creation_time": "2019-04-18T18:01:33",
-        "target_milestone": None,
-        "keywords": [],
-        "summary": "[abrt] gnome-software: gtk_widget_unparent(): gnome-software killed by SIGSEGV",
-        "cf_ovirt_team": "",
-        "cf_release_notes": "",
-        "cf_cloudforms_team": "",
-        "cf_type": "",
-        "cf_fixed_in": "",
-        "cf_atomic": "",
-        "id": 1701353,
-        "priority": "unspecified",
-        "platform": "x86_64",
-        "version": {
-          "id": 5713,
-          "name": "30"
-        },
-        "cf_regression_status": "",
-        "cf_environment": "",
-        "status": {
-          "id": 1,
-          "name": "NEW"
-        },
-        "product": {
-          "id": 49,
-          "name": "Fedora"
-        },
-        "qa_contact": {
-          "login": "extras-qa@fedoraproject.org",
-          "id": 171387,
-          "real_name": "Fedora Extras Quality Assurance"
-        },
-        "reporter": {
-          "login": "peter@sonniger-tag.eu",
-          "id": 361290,
-          "real_name": "Peter"
-        },
-        "component": {
-          "id": 126541,
-          "name": "gnome-software"
-        },
-        "cf_category": "",
-        "cf_doc_type": "If docs needed, set a value",
-        "cf_documentation_action": "",
-        "cf_clone_of": "",
-        "is_private": False,
-        "severity": "unspecified",
-        "operating_system": "Unspecified",
-        "url": "https://retrace.fedoraproject.org/faf/reports/bthash/f4ca1e58d66fb046d6d1d1b18a84dd779ad34624",
-        "last_change_time": "2019-04-18T18:01:50",
-        "cf_crm": "",
-        "cf_last_closed": None,
-        "alias": [],
-        "flags": [],
-        "assigned_to": {
-          "login": "rhughes@redhat.com",
-          "id": 213548,
-          "real_name": "Richard Hughes"
-        },
-        "resolution": "",
-        "cf_mount_type": ""
-      },
-      "is_private": False
-    },
-    "event": {
-      "target": "attachment",
-      "change_set": "78355.1555610511.09385",
-      "routing_key": "attachment.create",
-      "bug_id": 1701353,
-      "user": {
-        "login": "peter@sonniger-tag.eu",
-        "id": 361290,
-        "real_name": "Peter"
-      },
-      "time": "2019-04-18T18:01:51",
-      "action": "create"
-    }
-  }
-}
-
-# sample private message
-PRIVATE = {
-  "username": None,
-  "source_name": "datanommer",
-  "certificate": None,
-  "i": 0,
-  "timestamp": 1555617948.0,
-  "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:8683",
-  "crypto": None,
-  "topic": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
-  "headers": {
-    "content-length": "391",
-    "expires": "1555704348944",
-    "esbMessageType": "bugzillaNotification",
-    "timestamp": "1555617948944",
-    "original-destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
-    "destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
-    "correlation-id": "1566656e-4163-4d02-856c-9a888ce482d8",
-    "priority": "4",
-    "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.bug.modify",
-    "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:8683",
-    "esbSourceSystem": "bugzilla"
-  },
-  "signature": None,
-  "source_version": "0.9.1",
-  "body": {
-    "event": {
-      "target": "bug",
-      "change_set": "123367.1555617940.83869",
-      "routing_key": "bug.modify",
-      "bug_id": 1493146,
-      "user": {
-        "login": "bob@roberts.com",
-        "id": 199080,
-        "real_name": "Bob Roberts"
-      },
-      "time": "2019-04-18T20:05:41",
-      "action": "modify",
-      "changes": [
-        {
-          "field": "cc",
-          "removed": "",
-          "added": "bob@roberts.com, rob@boberts.com"
-        },
-        {
-          "field": "flag.needinfo",
-          "removed": "",
-          "added": "? (rob@boberts.com)"
-        }
-      ]
-    }
-  }
-}
-
-# sample message for a different product
-OTHERPRODUCT = {
-  "username": None,
-  "source_name": "datanommer",
-  "certificate": None,
-  "i": 0,
-  "timestamp": 1555602888.0,
-  "msg_id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:6687",
-  "crypto": None,
-  "topic": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
-  "headers": {
-    "content-length": "1744",
-    "expires": "1555689288212",
-    "esbMessageType": "bugzillaNotification",
-    "timestamp": "1555602888212",
-    "original-destination": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
-    "destination": "/topic/VirtualTopic.eng.bugzilla.attachment.create",
-    "correlation-id": "6be413f1-5c44-4598-bca5-c0b07e5a4208",
-    "priority": "4",
-    "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
-    "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.attachment.create",
-    "message-id": "ID:messaging-devops-broker02.web.prod.ext.phx2.redhat.com-42079-1555559691665-1:361:-1:1:6687",
-    "esbSourceSystem": "bugzilla"
-  },
-  "signature": None,
-  "source_version": "0.9.1",
-  "body": {
-    "attachment": {
-      "description": "journalctl/systemctl output",
-      "file_name": "kubelet.tgz",
-      "is_patch": False,
-      "creation_time": "2019-04-18T15:54:39",
-      "id": 1556163,
-      "flags": [],
-      "last_change_time": "2019-04-18T15:54:39",
-      "content_type": "application/gzip",
-      "is_obsolete": False,
-      "bug": {
-        "whiteboard": "",
-        "classification": "Red Hat",
-        "cf_story_points": "",
-        "creation_time": "2019-04-18T15:46:21",
-        "target_milestone": None,
-        "keywords": [],
-        "summary": "One master shows not ready out of 3 after several hours post deployment.",
-        "cf_ovirt_team": "",
-        "cf_release_notes": "",
-        "cf_cloudforms_team": "",
-        "cf_type": "Bug",
-        "cf_fixed_in": "",
-        "cf_atomic": "",
-        "id": 1701324,
-        "priority": "unspecified",
-        "platform": "Unspecified",
-        "version": {
-          "id": 5777,
-          "name": "unspecified"
-        },
-        "cf_regression_status": "",
-        "cf_environment": "",
-        "status": {
-          "id": 1,
-          "name": "NEW"
-        },
-        "product": {
-          "id": 561,
-          "name": "Kubernetes-native Infrastructure"
-        },
-        "qa_contact": {
-          "login": "achernet@redhat.com",
-          "id": 391433,
-          "real_name": "Arik Chernetsky"
-        },
-        "reporter": {
-          "login": "sasha@redhat.com",
-          "id": 309636,
-          "real_name": "Alexander Chuzhoy"
-        },
-        "component": {
-          "id": 180277,
-          "name": "Deployment"
-        },
-        "cf_category": "",
-        "cf_doc_type": "If docs needed, set a value",
-        "cf_documentation_action": "",
-        "cf_clone_of": "",
-        "is_private": False,
-        "severity": "unspecified",
-        "operating_system": "Unspecified",
-        "url": "",
-        "last_change_time": "2019-04-18T15:46:40",
-        "cf_crm": "",
-        "cf_last_closed": None,
-        "alias": [],
-        "flags": [],
-        "assigned_to": {
-          "login": "athomas@redhat.com",
-          "id": 56702,
-          "real_name": "Angus Thomas"
-        },
-        "resolution": "",
-        "cf_mount_type": ""
-      },
-      "is_private": False
-    },
-    "event": {
-      "target": "attachment",
-      "change_set": "33145.1555602879.56178",
-      "routing_key": "attachment.create",
-      "bug_id": 1701324,
-      "user": {
-        "login": "sasha@redhat.com",
-        "id": 309636,
-        "real_name": "Alexander Chuzhoy"
-      },
-      "time": "2019-04-18T15:54:39",
-      "action": "create"
-    }
-  }
-}
-
 
 class TestRelay(object):
     relay = bugzilla2fedmsg.relay.MessageRelay({'bugzilla': {'products': ["Fedora", "Fedora EPEL"]}})
 
     @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
-    def test_bug_create(self, fakepublish):
+    def test_bug_create(self, fakepublish, bug_create_message):
         """Check correct result for bug.create message."""
-        self.relay.on_stomp_message(BUGCREATE['body'], BUGCREATE['headers'])
+        self.relay.on_stomp_message(bug_create_message['body'], bug_create_message['headers'])
         assert fakepublish.call_count == 1
         message = fakepublish.call_args[0][0]
         assert message.topic == 'bugzilla.bug.new'
@@ -678,9 +31,9 @@ class TestRelay(object):
         assert createtime == 1555619221.0
 
     @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
-    def test_bug_modify(self, fakepublish):
+    def test_bug_modify(self, fakepublish, bug_modify_message):
         """Check correct result for bug.modify message."""
-        self.relay.on_stomp_message(BUGMODIFY['body'], BUGMODIFY['headers'])
+        self.relay.on_stomp_message(bug_modify_message['body'], bug_modify_message['headers'])
         assert fakepublish.call_count == 1
         message = fakepublish.call_args[0][0]
         assert message.topic == 'bugzilla.bug.update'
@@ -688,9 +41,9 @@ class TestRelay(object):
         assert message.body['event']['routing_key'] == "bug.modify"
 
     @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
-    def test_comment_create(self, fakepublish):
+    def test_comment_create(self, fakepublish, comment_create_message):
         """Check correct result for comment.create message."""
-        self.relay.on_stomp_message(COMMENTCREATE['body'], COMMENTCREATE['headers'])
+        self.relay.on_stomp_message(comment_create_message['body'], comment_create_message['headers'])
         assert fakepublish.call_count == 1
         message = fakepublish.call_args[0][0]
         assert message.topic == 'bugzilla.bug.update'
@@ -707,9 +60,9 @@ class TestRelay(object):
         assert message.body['event']['routing_key'] == "comment.create"
 
     @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
-    def test_attachment_create(self, fakepublish):
+    def test_attachment_create(self, fakepublish, attachment_create_message):
         """Check correct result for attachment.create message."""
-        self.relay.on_stomp_message(ATTACHMENTCREATE['body'], ATTACHMENTCREATE['headers'])
+        self.relay.on_stomp_message(attachment_create_message['body'], attachment_create_message['headers'])
         assert fakepublish.call_count == 1
         message = fakepublish.call_args[0][0]
         assert message.topic == 'bugzilla.bug.update'
@@ -730,42 +83,42 @@ class TestRelay(object):
         assert message.body['event']['routing_key'] == "attachment.create"
 
     @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
-    def test_private_drop(self, fakepublish):
+    def test_private_drop(self, fakepublish, private_message):
         """Check that we drop (don't publish) a private message."""
-        self.relay.on_stomp_message(PRIVATE['body'], PRIVATE['headers'])
+        self.relay.on_stomp_message(private_message['body'], private_message['headers'])
         assert fakepublish.call_count == 0
 
     @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
-    def test_other_product_drop(self, fakepublish):
+    def test_other_product_drop(self, fakepublish, other_product_message):
         """Check that we drop (don't publish) a message for a product
         we don't want to cover. As our fake hub doesn't really have a
         config, the products we care about are the defaults: 'Fedora'
         and 'Fedora EPEL'.
         """
-        self.relay.on_stomp_message(OTHERPRODUCT['body'], OTHERPRODUCT['headers'])
+        self.relay.on_stomp_message(other_product_message['body'], other_product_message['headers'])
         assert fakepublish.call_count == 0
 
     @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
-    def test_publish_exception_publishreturned(self, fakepublish, caplog):
+    def test_publish_exception_publishreturned(self, fakepublish, bug_create_message, caplog):
         """Check that we handle PublishReturned exception from publish
         correctly.
         """
         fakepublish.side_effect = fedora_messaging.exceptions.PublishReturned("oops!")
         # this should not raise any exception
-        self.relay.on_stomp_message(BUGCREATE['body'], BUGCREATE['headers'])
+        self.relay.on_stomp_message(bug_create_message['body'], bug_create_message['headers'])
         assert fakepublish.call_count == 1
         # check the logging worked
         assert "Fedora Messaging broker rejected message" in caplog.text
 
     @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
-    def test_publish_exception_connectionexception(self, fakepublish, caplog):
+    def test_publish_exception_connectionexception(self, fakepublish, bug_create_message, caplog):
         """Check that we handle ConnectionException from publish
         correctly.
         """
         # First test PublishReturned
         fakepublish.side_effect = fedora_messaging.exceptions.ConnectionException("oops!")
         # this should not raise any exception
-        self.relay.on_stomp_message(BUGCREATE['body'], BUGCREATE['headers'])
+        self.relay.on_stomp_message(bug_create_message['body'], bug_create_message['headers'])
         assert fakepublish.call_count == 1
         # check the logging worked
         assert "Error sending message" in caplog.text

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -5,9 +5,7 @@ Authors:    Adam Williamson <awilliam@redhat.com>
 
 """
 
-import datetime
 import mock
-import pytz
 import bugzilla2fedmsg.relay
 
 # sample public bug creation messages
@@ -676,7 +674,7 @@ class TestRelay(object):
         assert message.body['bug']['op_sys'] == "Unspecified"
         # this tests convert_datetimes
         createtime = message.body['bug']['creation_time']
-        assert createtime == datetime.datetime.fromtimestamp(1555619221, pytz.UTC)
+        assert createtime == 1555619221.0
 
     @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
     def test_bug_modify(self, fakepublish):
@@ -698,7 +696,7 @@ class TestRelay(object):
         assert message.body['comment'] == {
             "author": "smooge@redhat.com",
             "body": "qa09 and qa14 have 8 560 GB SAS drives which are RAID-6 together. \n\nThe systems we get from IBM come through a special contract which in the past required the system to be sent back to add hardware to it. When we added drives it also caused problems because the system didn't match the contract when we returned it. I am checking with IBM on the wearabouts for the systems.",
-            "creation_time": datetime.datetime.fromtimestamp(1555602938, pytz.UTC),
+            "creation_time": 1555602938.0,
             "number": 8,
             "id": 1691487,
             "is_private": False,
@@ -718,10 +716,10 @@ class TestRelay(object):
             "description": "File: var_log_messages",
             "file_name": "var_log_messages",
             "is_patch": False,
-            "creation_time": datetime.datetime.fromtimestamp(1555610511, pytz.UTC),
+            "creation_time": 1555610511.0,
             "id": 1556193,
             "flags": [],
-            "last_change_time": datetime.datetime.fromtimestamp(1555610511, pytz.UTC),
+            "last_change_time": 1555610511.0,
             "content_type": "text/plain",
             "is_obsolete": False,
             "is_private": False,

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = True
 
 [testenv]
 deps =
-    pytest
+    pytest >= 3.3.0
     pytest-cov
     pytz
     mock

--- a/tox.ini
+++ b/tox.ini
@@ -37,3 +37,4 @@ exclude = .git,.tox,dist,*egg
 # example messages and it'd be painful to manually wrap them all
 per-file-ignores =
     tests/test_relay.py:E501
+    tests/conftest.py:E501


### PR DESCRIPTION
Another kinda grab-bag of Bugzilla 5 and fedora-messaging related stuff.

"Don't try and publish datetimes" is a straight up bug fix - we can't send native datetime objects to fedora-messaging's `publish()` the way we could for fedmsg, so we shouldn't try and do that.

"Add tests for handling of exceptions from publish()" is just a test improvement - for some reason the coverage diff would fail for the following commit even though it didn't touch those lines, so hey, let's cover them.

"Don't 'organize' the message as it comes off the BZ wire"  drops the whole 'expected bug fields' thing where we define fields we expect to send out and modify the message to match. This just doesn't seem necessary any more (and many of the fields *aren't* in the messages we get from Bugzilla, so we're just constantly sending out `None`s for those). Let's just pass along whatever the upstream message gives us.

"Make test messages into pytest fixtures" is basically there so a subsequent commit can re-use one of the test messages in multiple tests. We *could* change the relay implementation so it takes a deep copy of the body dict to avoid modifying the original, instead of or as well as doing this; I'm not sure if it's *necessary*, though. It depends whether there's a possibility of anything else expecting to be able to do something with the `body` dict that is passed to `on_stomp_message` after that method is done with it.

"Extend backwards compatibility a bit" enhances the 'backwards compatibility' blob a bit to cover some more cases where the fedmsg_meta processor expects the message to look a certain way, but our Bugzilla 5-derived messages do not look that way. Specifically, it expects the 'component' to be just a string not a dict (rather like the 'product'), and it expects a 'weburl' in the bug dict, which should be the URL for the bug.

"Make Bugzilla 4 backwards compatibility transformation optional" makes the whole 'backwards compatibility' thing optional (defaulting to enabled), and renames it to be more specific about what it is - compatibility with how the messages looked in the Bugzilla 4 era. I think we should be aiming to make all consumers of these messages handle the dicts just as they come out of upstream Bugzilla, and get rid of this 'backwards compatibility' stuff; making it a run-time configuration option should ease the process of doing that.