### PR TITLE
Implement message schemas

### DIFF
--- a/bugzilla2fedmsg/relay.py
+++ b/bugzilla2fedmsg/relay.py
@@ -2,8 +2,11 @@ import datetime
 import logging
 
 import pytz
-from fedora_messaging.api import Message, publish
+from fedora_messaging.api import publish
 from fedora_messaging.exceptions import PublishReturned, ConnectionException
+from fedora_messaging.message import INFO
+
+from bugzilla2fedmsg_schema.schema import MessageV1, MessageV1BZ4
 
 from .utils import convert_datetimes
 
@@ -103,10 +106,14 @@ class MessageRelay:
         body.update(objdict)
 
         LOGGER.debug("Republishing #%s" % bug['id'])
+        messageclass = MessageV1
+        if self._bz4_compat_mode:
+            messageclass = MessageV1BZ4
         try:
-            message = Message(
+            message = messageclass(
                 topic="bugzilla.{}".format(topic),
                 body=body,
+                severity=INFO,
             )
             publish(message)
         except PublishReturned as e:

--- a/bugzilla2fedmsg_schema/schema.py
+++ b/bugzilla2fedmsg_schema/schema.py
@@ -1,0 +1,358 @@
+"""fedora-messaging schema for bugzilla2fedmsg."""
+
+import copy
+
+from fedora_messaging import message
+from fedora_messaging.schema_utils import libravatar_url
+from .utils import comma_join, email_to_fas
+
+
+class BaseMessage(message.Message):
+    """
+    Base message class for all message versions and variants.
+    """
+
+    def __str__(self):
+        """We just use the summary for now."""
+        return self.summary
+
+    @property
+    def summary(self):
+        """A summary of the message."""
+        (user, _) = email_to_fas(self._primary_email)
+        idx = self.bug['id']
+        title = self.bug['summary']
+        action = self.body['event']['action']
+        target = self.body['event']['target']
+
+        if len(title) > 40:
+            title = title[:40] + "..."
+
+        if target == "bug" and action == "create":
+            tmpl = "{user} filed a new bug RHBZ#{idx} '{title}'"
+            return tmpl.format(user=user, idx=idx, title=title)
+
+        elif self.body['event']['action'] == "create":
+            tmpl = "{user} added {target} on RHBZ#{idx} '{title}'"
+            return tmpl.format(user=user, target=target, idx=idx, title=title)
+
+        # at this point 'action' must be "modify": we're modifying the
+        # target
+        fields = [d['field'] for d in self.body['event'].get('changes', [])]
+        fields = comma_join(fields)
+        if target == "bug":
+            tmpl = "{user} updated {fields} on RHBZ#{idx} '{title}'"
+            return tmpl.format(user=user, fields=fields, idx=idx, title=title)
+        tmpl = "{user} updated {fields} for {target} on RHBZ#{idx} '{title}'"
+        return tmpl.format(user=user, fields=fields, target=target, idx=idx, title=title)
+
+    @property
+    def url(self):
+        """The URL for the bug.
+
+        Returns:
+            str: A relevant URL.
+        """
+        return "https://bugzilla.redhat.com/show_bug.cgi?id={}".format(self.bug['id'])
+
+    @property
+    def app_icon(self):
+        """An URL to the icon of the application that generated the message."""
+        return "https://bugzilla.redhat.com/extensions/RedHat/web/css/favicon.ico?v=0"
+
+    @property
+    def usernames(self):
+        """List of users affected by the action that generated this message."""
+        users = set()
+        emails = self._all_emails
+        for email in emails:
+            (user, is_fas) = email_to_fas(email)
+            if is_fas:
+                users.add(user)
+        return list(users)
+
+    @property
+    def packages(self):
+        """List of packages affected by the action that generated this message."""
+        compname = self.component_name
+        # these are Bugzilla components that are not Fedora packages
+        # add any more you can think of
+        notpackages = [
+            'distribution',
+            'LiveCD',
+            'LiveCD - FEL',
+            'LiveCD - Games',
+            'LiveCD - KDE',
+            'LiveCD - LXDE',
+            'LiveCD - Xfce',
+            'Package Review',
+        ]
+        if compname in notpackages:
+            return []
+        return [compname]
+
+    @property
+    def agent_avatar(self):
+        """URL to the avatar of the user who caused the action."""
+        return libravatar_url(self._primary_email)
+
+    @property
+    def _primary_email(self):
+        """The email for the primary user associated with the action
+        that generated this message.
+        """
+        return self.body['event']['user']['login']
+
+    @property
+    def _all_emails(self):
+        """List of email addresses of all users relevant to the action
+        that generated this message.
+        """
+        users = set()
+
+        # user from the event dict: person who triggered the event
+        users.add(self._primary_email)
+
+        # bug reporter and assignee
+        users.add(self.bug['reporter']['login'])
+        users.add(self.assigned_to_email)
+
+        for change in self.body['event'].get('changes', []):
+            if change['field'] == "cc":
+                # anyone added to CC list
+                for user in change['added'].split(','):
+                    user.strip()
+                    if user:
+                        users.add(user)
+            elif change['field'] == "flag.needinfo":
+                # anyone for whom a 'needinfo' flag is set
+                # this is extracting the email from a value like:
+                # "? (senrique@redhat.com)"
+                user = change['added'].split('(', 1)[1].rsplit(')', 1)[0]
+                if user:
+                    users.add(user)
+
+        # Strip anything that made it in erroneously
+        for user in list(users):
+            if user.endswith('lists.fedoraproject.org'):
+                users.remove(user)
+
+        users = list(users)
+        users.sort()
+        return users
+
+
+class MessageV1(BaseMessage):
+    """
+    A sub-class of a Fedora message that defines a message schema for messages
+    published by Bugzilla. This schema is accurate for messages emitted since
+    bugzilla2fedmsg commit 08b3e0c5 with Bugzilla 4 compatibility DISABLED.
+    """
+
+    body_schema = {
+        "id": "http://fedoraproject.org/message-schema/bugzilla2fedmsg#",
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "description": "Schema for message sent by Bugzilla (v1, BZ4 compat disabled)",
+        "type": "object",
+        "properties": {
+            "bug": {
+                "description": "An object representing the relevant bug itself",
+                "type": "object",
+                "properties": {
+                    "alias": {"type": "array"},
+                    "assigned_to": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "number"},
+                            "login": {"type": "string"},
+                            "real_name": {"type": "string"},
+                        },
+                    },
+                    "classification": {"type": "string"},
+                    "component": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "number"},
+                            "name": {"type": "string"},
+                        },
+                    },
+                    "creation_time": {"type": "number"},
+                    "flags": {"type": "array"},
+                    "id": {"type": "number"},
+                    "is_private": {"type": "boolean"},
+                    "keywords": {"type": "array"},
+                    "last_change_time": {"type": "number"},
+                    "operating_system": {"type": "string"},
+                    "platform": {"type": "string"},
+                    "priority": {"type": "string"},
+                    "product": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "number"},
+                            "name": {"type": "string"},
+                        },
+                    },
+                    "qa_contact": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "number"},
+                            "login": {"type": "string"},
+                            "real_name": {"type": "string"},
+                        },
+                    },
+                    "reporter": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "number"},
+                            "login": {"type": "string"},
+                            "real_name": {"type": "string"},
+                        },
+                    },
+                    "resolution": {"type": "string"},
+                    "severity": {"type": "string"},
+                    "status": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "number"},
+                            "name": {"type": "string"},
+                        },
+                    },
+                    "summary": {"type": "string"},
+                    "url": {"type": "string"},
+                    "version": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "number"},
+                            "name": {"type": "string"},
+                        },
+                    },
+                    "whiteboard": {"type": "string"},
+                },
+                "required": ["alias", "assigned_to", "classification", "component",
+                             "creation_time", "flags", "id", "is_private", "keywords",
+                             "last_change_time", "operating_system", "platform", "priority",
+                             "product", "qa_contact", "reporter", "resolution", "severity",
+                             "status", "summary", "url", "version", "whiteboard"],
+            },
+            "event": {
+                "description": "An object representing the event the message relates to",
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string"},
+                    "bug_id": {"type": "number"},
+                    "changes": {"type": "array"},
+                    "change_set": {"type": "string"},
+                    "routing_key": {"type": "string"},
+                    "rule_id": {"type": "number"},
+                    "target": {"type": "string"},
+                    "time": {"type": "number"},
+                    "user": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "number"},
+                            "login": {"type": "string"},
+                            "real_name": {"type": "string"},
+                        },
+                    },
+                },
+                "required": ["action", "bug_id", "change_set", "routing_key", "target",
+                             "time", "user"],
+            },
+            "comment": {
+                "description": "An object representing a comment affected by the event",
+                "type": "object",
+                "properties": {
+                    "body": {"type": "string"},
+                    "creation_time": {"type": "number"},
+                    "id": {"type": "number"},
+                    "is_private": {"type": "boolean"},
+                    "number": {"type": "number"},
+                },
+                "required": ["body", "creation_time", "id", "is_private", "number"],
+            },
+            "attachment": {
+                "description": "An object representing an attachment affected by the event",
+                "properties": {
+                    "content_type": {"type": "string"},
+                    "creation_time": {"type": "number"},
+                    "description": {"type": "string"},
+                    "file_name": {"type": "string"},
+                    "flags": {"type": "array"},
+                    "id": {"type": "number"},
+                    "is_obsolete": {"type": "boolean"},
+                    "is_patch": {"type": "boolean"},
+                    "is_private": {"type": "boolean"},
+                    "last_change_time": {"type": "number"},
+                },
+                "required": ["content_type", "creation_time", "description", "file_name",
+                             "flags", "id", "is_obsolete", "is_patch", "is_private",
+                             "last_change_time"],
+            },
+        },
+        "required": ["bug", "event"],
+    }
+
+    @property
+    def bug(self):
+        """The bug dictionary from the message."""
+        return self.body['bug']
+
+    @property
+    def assigned_to_email(self):
+        """The email address of the user to which the bug is assigned."""
+        return self.bug['assigned_to']['login']
+
+    @property
+    def component_name(self):
+        """The name of the component against which the bug is filed."""
+        return self.bug['component']['name']
+
+    @property
+    def product_name(self):
+        """The name of the product against which the bug is filed."""
+        return self.bug['product']['name']
+
+
+class MessageV1BZ4(MessageV1):
+    """
+    A sub-class of a Fedora message that defines a message schema for messages
+    published by Bugzilla. This schema is accurate for messages emitted since
+    bugzilla2fedmsg commit 08b3e0c5 with Bugzilla 4 compatibility ENABLED.
+    """
+
+    body_schema = copy.deepcopy(MessageV1.body_schema)
+    bug = body_schema["properties"]["bug"]
+    event = body_schema["properties"]["event"]
+    comment = body_schema["properties"]["comment"]
+    bug["properties"]["assigned_to"] = {"type": "string"}
+    bug["properties"]["component"] = {"type": "string"}
+    bug["properties"]["product"] = {"type": "string"}
+    bug["properties"]["cc"] = {"type": "array"}
+    bug["properties"]["creator"] = {"type": "string"}
+    bug["properties"]["op_sys"] = {"type": "string"}
+    bug["properties"]["weburl"] = {"type": "string"}
+    bug["required"].extend(["cc", "weburl"])
+    event["properties"]["who"] = {"type": "string"}
+    event["required"].append("who")
+    comment["properties"]["author"] = {"type": "string"}
+    comment["required"].append("author")
+
+    @property
+    def bug(self):
+        """The bug dictionary from the message."""
+        return self.body['bug']
+
+    @property
+    def assigned_to_email(self):
+        """The email address of the user to which the bug is assigned."""
+        return self.bug['assigned_to']
+
+    @property
+    def component_name(self):
+        """The name of the component against which the bug is filed."""
+        return self.bug['component']
+
+    @property
+    def product_name(self):
+        """The name of the product against which the bug is filed."""
+        return self.bug['product']

--- a/bugzilla2fedmsg_schema/utils.py
+++ b/bugzilla2fedmsg_schema/utils.py
@@ -1,0 +1,35 @@
+"""This contains utils to parse the message."""
+
+
+def comma_join(fields, oxford=True):
+    """ Join together words. """
+
+    def fmt(field):
+        return "'%s'" % field
+
+    if not fields:
+        # unfortunately this happens: we get 'modify' messages with no
+        # 'changes', so we don't know what changed
+        return "something unknown"
+    elif len(fields) == 1:
+        return fmt(fields[0])
+    elif len(fields) == 2:
+        return " and ".join([fmt(f) for f in fields])
+    else:
+        result = ", ".join([fmt(f) for f in fields[:-1]])
+        if oxford:
+            result += ","
+        result += " and %s" % fmt(fields[-1])
+        return result
+
+
+def email_to_fas(email):
+    """Try to get a FAS username from an email address. For now, this
+    is a dumb version which just does the 'easy' part of what the full
+    fat fedmsg_meta email2fas did - for fedoraproject.org addresses,
+    we can just do this easily. For all other addresses, we really
+    need that full feature added to fedora-messaging.
+    """
+    if email.endswith('@fedoraproject.org'):
+        return (email.rsplit('@', 1)[0], True)
+    return (email, False)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,10 @@ setup(
     ],
     packages=find_packages(),
     entry_points={
-        "console_scripts": ["bugzilla2fedmsg=bugzilla2fedmsg:cli"]
+        "console_scripts": ["bugzilla2fedmsg=bugzilla2fedmsg:cli"],
+        "fedora.messages": [
+            "bugzilla2fedmsg.messageV1bz4=bugzilla2fedmsg_schema.schema:MessageV1BZ4",
+            "bugzilla2fedmsg.messageV1=bugzilla2fedmsg_schema.schema:MessageV1",
+        ],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,7 +236,153 @@ def bug_modify_message(request):
             {
               "field": "cc",
               "removed": "",
-              "added": "mhroncok@redhat.com"
+              # this is changed from the original message (mhroncok
+              # actually CCed himself) to help with tests
+              "added": "awilliam@redhat.com"
+            }
+          ]
+        }
+      }
+    }
+
+
+@pytest.fixture(scope="function")
+def bug_modify_message_four_changes(request):
+    """Sample upstream bug.modify message with four changes."""
+    return {
+      "username": None,
+      "source_name": "datanommer",
+      "certificate": None,
+      "i": 0,
+      "timestamp": 1556151843.0,
+      "msg_id": "ID:messaging-devops-broker01.web.prod.ext.phx2.redhat.com-44024-1556115643434-1:509:-1:1:4467",
+      "crypto": None,
+      "topic": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
+      "headers": {
+        "content-length": "1756",
+        "expires": "1556238243956",
+        "esbMessageType": "bugzillaNotification",
+        "timestamp": "1556151843956",
+        "original-destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
+        "destination": "/topic/VirtualTopic.eng.bugzilla.bug.modify",
+        "correlation-id": "8b311d06-bd03-444f-aaec-ff2735b53424",
+        "priority": "4",
+        "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.bug.modify",
+        "message-id": "ID:messaging-devops-broker01.web.prod.ext.phx2.redhat.com-44024-1556115643434-1:509:-1:1:4467",
+        "esbSourceSystem": "bugzilla"
+      },
+      "signature": None,
+      "source_version": "0.9.1",
+      "body": {
+        "bug": {
+          "whiteboard": "",
+          "classification": "Fedora",
+          "cf_story_points": "",
+          "creation_time": "2019-04-24T14:00:14",
+          "target_milestone": None,
+          "keywords": [],
+          "summary": "Review Request: perl-Class-AutoClass - Define classes and objects for Perl",
+          "cf_ovirt_team": "",
+          "cf_release_notes": "",
+          "cf_cloudforms_team": "",
+          "cf_type": "",
+          "cf_fixed_in": "",
+          "cf_atomic": "",
+          "id": 1702701,
+          "priority": "medium",
+          "platform": "All",
+          "version": {
+            "id": 495,
+            "name": "rawhide"
+          },
+          "cf_regression_status": "",
+          "cf_environment": "",
+          "status": {
+            "id": 26,
+            "name": "POST"
+          },
+          "product": {
+            "id": 49,
+            "name": "Fedora"
+          },
+          "qa_contact": {
+            "login": "extras-qa@fedoraproject.org",
+            "id": 171387,
+            "real_name": "Fedora Extras Quality Assurance"
+          },
+          "reporter": {
+            "login": "ppisar@redhat.com",
+            "id": 295770,
+            "real_name": "Petr Pisar"
+          },
+          "component": {
+            "id": 18186,
+            "name": "Package Review"
+          },
+          "cf_category": "",
+          "cf_doc_type": "If docs needed, set a value",
+          "cf_documentation_action": "",
+          "cf_clone_of": "",
+          "is_private": False,
+          "severity": "medium",
+          "operating_system": "Linux",
+          "url": "",
+          "last_change_time": "2019-04-24T14:00:14",
+          "cf_crm": "",
+          "cf_last_closed": None,
+          "alias": [],
+          "flags": [
+            {
+              "id": 4029953,
+              "value": "+",
+              "name": "fedora-review"
+            }
+          ],
+          "assigned_to": {
+            "login": "zebob.m@gmail.com",
+            "id": 401767,
+            "real_name": "Robert-Andr\u00e9 Mauchin"
+          },
+          "resolution": "",
+          "cf_mount_type": ""
+        },
+        "event": {
+          "target": "bug",
+          "change_set": "113867.1556151814.59504",
+          "routing_key": "bug.modify",
+          "bug_id": 1702701,
+          "user": {
+            "login": "zebob.m@gmail.com",
+            "id": 401767,
+            "real_name": "Robert-Andr\u00e9 Mauchin"
+          },
+          "time": "2019-04-25T00:23:35",
+          "action": "modify",
+          "changes": [
+            {
+              "field": "assigned_to",
+              "removed": "nobody@fedoraproject.org",
+              "added": "zebob.m@gmail.com"
+            },
+            {
+              "field": "bug_status",
+              "removed": "NEW",
+              "added": "POST"
+            },
+            {
+              "field": "cc",
+              "removed": "",
+              "added": "zebob.m@gmail.com"
+            },
+            # changed from original message: in original message this
+            # was a flag.fedora-review change, we make it a needinfo
+            # change so we can test gathering user from needinfo
+            {
+              "field": "flag.needinfo",
+              "removed": "",
+              "added": "? (rob@boberts.com)"
             }
           ]
         }
@@ -484,6 +630,138 @@ def attachment_create_message(request):
           },
           "time": "2019-04-18T18:01:51",
           "action": "create"
+        }
+      }
+    }
+
+
+@pytest.fixture(scope="function")
+def attachment_modify_message(request):
+    """Sample upstream attachment.modify message."""
+    return {
+      "username": None,
+      "source_name": "datanommer",
+      "certificate": None,
+      "i": 0,
+      "timestamp": 1556149890.0,
+      "msg_id": "ID:messaging-devops-broker01.web.prod.ext.phx2.redhat.com-44024-1556115643434-1:509:-1:1:4401",
+      "crypto": None,
+      "topic": "/topic/VirtualTopic.eng.bugzilla.attachment.modify",
+      "headers": {
+        "content-length": "1861",
+        "expires": "1556236290607",
+        "esbMessageType": "bugzillaNotification",
+        "timestamp": "1556149890607",
+        "original-destination": "/topic/VirtualTopic.eng.bugzilla.attachment.modify",
+        "destination": "/topic/VirtualTopic.eng.bugzilla.attachment.modify",
+        "correlation-id": "0e227da5-88fe-492a-b426-f1f9b11fab86",
+        "priority": "4",
+        "subscription": "/queue/Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_destination": "queue://Consumer.client-datanommer.upshift-prod.VirtualTopic.eng.>",
+        "amq6100_originalDestination": "topic://VirtualTopic.eng.bugzilla.attachment.modify",
+        "message-id": "ID:messaging-devops-broker01.web.prod.ext.phx2.redhat.com-44024-1556115643434-1:509:-1:1:4401",
+        "esbSourceSystem": "bugzilla"
+      },
+      "signature": None,
+      "source_version": "0.9.1",
+      "body": {
+        "attachment": {
+          "description": "patch to turn off reset quirk for SP1064 touch pad",
+          "file_name": "kernel-diff.patch",
+          "is_patch": True,
+          "creation_time": "2019-04-24T23:36:57",
+          "id": 1558429,
+          "flags": [],
+          "last_change_time": "2019-04-24T23:36:57",
+          "content_type": "text/plain",
+          "is_obsolete": True,
+          "bug": {
+            "whiteboard": "",
+            "classification": "Fedora",
+            "cf_story_points": "",
+            "creation_time": "2019-04-21T17:46:11",
+            "target_milestone": None,
+            "keywords": [],
+            "summary": "I2C_HID_QUIRK_NO_IRQ_AFTER_RESET caused teclast f7/ apollo_lake using i2c_hid.c driver to have stuck button down after period of time",
+            "cf_ovirt_team": "",
+            "cf_release_notes": "",
+            "cf_cloudforms_team": "",
+            "cf_type": "Bug",
+            "cf_fixed_in": "",
+            "cf_atomic": "",
+            "id": 1701766,
+            "priority": "unspecified",
+            "platform": "All",
+            "version": {
+              "id": 495,
+              "name": "rawhide"
+            },
+            "cf_regression_status": "",
+            "cf_environment": "",
+            "status": {
+              "id": 1,
+              "name": "NEW"
+            },
+            "product": {
+              "id": 49,
+              "name": "Fedora"
+            },
+            "qa_contact": {
+              "login": "extras-qa@fedoraproject.org",
+              "id": 171387,
+              "real_name": "Fedora Extras Quality Assurance"
+            },
+            "reporter": {
+              "login": "joequant@gmail.com",
+              "id": 356480,
+              "real_name": "Joseph Wang"
+            },
+            "component": {
+              "id": 11769,
+              "name": "kernel"
+            },
+            "cf_category": "",
+            "cf_doc_type": "If docs needed, set a value",
+            "cf_documentation_action": "",
+            "cf_clone_of": "",
+            "is_private": False,
+            "severity": "high",
+            "operating_system": "Linux",
+            "url": "",
+            "last_change_time": "2019-04-24T23:43:07",
+            "cf_crm": "",
+            "cf_last_closed": None,
+            "alias": [],
+            "flags": [],
+            "assigned_to": {
+              "login": "kernel-maint@redhat.com",
+              "id": 176318,
+              "real_name": "Kernel Maintainer List"
+            },
+            "resolution": "",
+            "cf_mount_type": ""
+          },
+          "is_private": False
+        },
+        "event": {
+          "target": "attachment",
+          "change_set": "105535.1556149887.38751",
+          "routing_key": "attachment.modify",
+          "bug_id": 1701766,
+          "user": {
+            "login": "joequant@gmail.com",
+            "id": 356480,
+            "real_name": "Joseph Wang"
+          },
+          "time": "2019-04-24T23:51:27",
+          "action": "modify",
+          "changes": [
+            {
+              "field": "isobsolete",
+              "removed": "0",
+              "added": "1"
+            }
+          ]
         }
       }
     }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+""" Tests for bugzilla2fedmsg_schemas.
+
+Authors:    Adam Williamson <awilliam@redhat.com>
+
+"""
+
+import mock
+import pytest
+
+import bugzilla2fedmsg.relay
+
+
+class TestSchemas(object):
+    # We are basically going to use the relays to construct messages
+    # just as we do in test_relay, then check the messages validate
+    # and test the various schema methods. We parametrize the tests
+    # to test all the schema versions
+    bz4relay = bugzilla2fedmsg.relay.MessageRelay(
+        {'bugzilla': {'products': ["Fedora", "Fedora EPEL"], 'bz4compat': True}})
+    nobz4relay = bugzilla2fedmsg.relay.MessageRelay(
+        {'bugzilla': {'products': ["Fedora", "Fedora EPEL"], 'bz4compat': False}})
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_bug_create_schema(self, fakepublish, bug_create_message, relay):
+        """Check bug.create message schema bits."""
+        relay.on_stomp_message(bug_create_message['body'], bug_create_message['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.assigned_to_email == "lvrabec@redhat.com"
+        assert message.component_name == "selinux-policy"
+        assert message.product_name == "Fedora"
+        assert message.summary == "dgunchev@gmail.com filed a new bug RHBZ#1701391 'SELinux is preventing touch from 'write'...'"
+        assert str(message) == "dgunchev@gmail.com filed a new bug RHBZ#1701391 'SELinux is preventing touch from 'write'...'"
+        assert message.url == "https://bugzilla.redhat.com/show_bug.cgi?id=1701391"
+        assert message.app_icon == "https://bugzilla.redhat.com/extensions/RedHat/web/css/favicon.ico?v=0"
+        # broken till we can do email2fas
+        assert message.usernames == []
+        assert message.packages == ['selinux-policy']
+        assert message.agent_avatar == "https://seccdn.libravatar.org/avatar/d4bfc5ec5260361c930aad299c8e14fe03af45109ea88e880a191851b8c83e7f?s=64&d=retro"
+        assert message._primary_email == "dgunchev@gmail.com"
+        assert message._all_emails == ["dgunchev@gmail.com", "lvrabec@redhat.com"]
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_bug_modify_schema(self, fakepublish, bug_modify_message, relay):
+        """Check bug.modify message schema bits."""
+        relay.on_stomp_message(bug_modify_message['body'], bug_modify_message['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.summary == "mhroncok@redhat.com updated 'cc' on RHBZ#1699203 'python-pyramid-1.10.4 is available'"
+        # here we test both picking up an address from a 'cc' change
+        # event, and filtering out lists.fedoraproject.org addresses
+        assert message._all_emails == ["awilliam@redhat.com", "mhroncok@redhat.com", "upstream-release-monitoring@fedoraproject.org"]
+        # here we test that we can at least derive usernames from
+        # fedoraproject.org email addresses
+        assert message.usernames == ['upstream-release-monitoring']
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_bug_modify_four_changes_schema(self, fakepublish, bug_modify_message_four_changes, relay):
+        """Check bug.modify message schema bits when the message
+        includes four changes (this exercises comma_join).
+        """
+        relay.on_stomp_message(bug_modify_message_four_changes['body'], bug_modify_message_four_changes['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.summary == "zebob.m@gmail.com updated 'assigned_to', 'bug_status', 'cc', and 'flag.needinfo' on RHBZ#1702701 'Review Request: perl-Class-AutoClass - D...'"
+        # this tests gathering an address from a 'needinfo' change
+        assert message._all_emails == ["ppisar@redhat.com", "rob@boberts.com", "zebob.m@gmail.com"]
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_bug_modify_two_changes_schema(self, fakepublish, bug_modify_message_four_changes, relay):
+        """Check bug.modify message schema bits when the message
+        includes two changes (this exercises a slightly different
+        comma_join path).
+        """
+        # Just dump two changes from the 'four changes' message
+        bug_modify_message_four_changes['body']['event']['changes'] = bug_modify_message_four_changes['body']['event']['changes'][:2]
+        relay.on_stomp_message(bug_modify_message_four_changes['body'], bug_modify_message_four_changes['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.summary == "zebob.m@gmail.com updated 'assigned_to' and 'bug_status' on RHBZ#1702701 'Review Request: perl-Class-AutoClass - D...'"
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_bug_modify_no_changes_schema(self, fakepublish, bug_modify_message, relay):
+        """Check bug.modify message schema bits when event is missing
+        'changes' - we often get messages like this, for some reason.
+        """
+        # wipe the 'changes' dict from the sample message, to simulate
+        # one of these broken messages
+        del bug_modify_message['body']['event']['changes']
+        relay.on_stomp_message(bug_modify_message['body'], bug_modify_message['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.summary == "mhroncok@redhat.com updated something unknown on RHBZ#1699203 'python-pyramid-1.10.4 is available'"
+        assert message._all_emails == ["mhroncok@redhat.com", "upstream-release-monitoring@fedoraproject.org"]
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_comment_create_schema(self, fakepublish, comment_create_message, relay):
+        """Check comment.create message schema bits."""
+        relay.on_stomp_message(comment_create_message['body'], comment_create_message['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.summary == "smooge@redhat.com added comment on RHBZ#1691487 'openQA transient test failure as duplica...'"
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_attachment_create_schema(self, fakepublish, attachment_create_message, relay):
+        """Check attachment.create message schema bits."""
+        relay.on_stomp_message(attachment_create_message['body'], attachment_create_message['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.summary == "peter@sonniger-tag.eu added attachment on RHBZ#1701353 '[abrt] gnome-software: gtk_widget_unpare...'"
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_attachment_modify_schema(self, fakepublish, attachment_modify_message, relay):
+        """Check attachment.modify message schema bits."""
+        relay.on_stomp_message(attachment_modify_message['body'], attachment_modify_message['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.summary == "joequant@gmail.com updated 'isobsolete' for attachment on RHBZ#1701766 'I2C_HID_QUIRK_NO_IRQ_AFTER_RESET caused ...'"
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_attachment_modify_no_changes_schema(self, fakepublish, attachment_modify_message, relay):
+        """Check attachment.modify message schema bits when event is
+        missing 'changes' - unlike the bug.modify case I have not
+        actually seen a message like this in the wild, but we do
+        handle it just in case.
+        """
+        # wipe the 'changes' dict from the sample message, to simulate
+        # one of these broken messages
+        del attachment_modify_message['body']['event']['changes']
+        relay.on_stomp_message(attachment_modify_message['body'], attachment_modify_message['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.summary == "joequant@gmail.com updated something unknown for attachment on RHBZ#1701766 'I2C_HID_QUIRK_NO_IRQ_AFTER_RESET caused ...'"
+
+    @pytest.mark.parametrize("relay", (bz4relay, nobz4relay))
+    @mock.patch('bugzilla2fedmsg.relay.publish', autospec=True)
+    def test_component_not_package_schema(self, fakepublish, bug_create_message, relay):
+        """Check we filter out components that aren't packages."""
+        # adjust the component in the sample message to one we should
+        # filter out
+        bug_create_message['body']['bug']['component']['name'] = 'distribution'
+        relay.on_stomp_message(bug_create_message['body'], bug_create_message['headers'])
+        assert fakepublish.call_count == 1
+        message = fakepublish.call_args[0][0]
+        # this should not raise an exception
+        message.validate()
+        assert message.packages == []

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pytz
     mock
 commands =
-    python -m pytest {posargs}
+    python -m pytest --cov=bugzilla2fedmsg --cov=bugzilla2fedmsg_schema {posargs}
 # When running in OpenShift you don't have a username, so expanduser
 # won't work. If you are running your tests in CentOS CI, this line is
 # important so the tests can pass there, otherwise tox will fail to find
@@ -37,4 +37,5 @@ exclude = .git,.tox,dist,*egg
 # example messages and it'd be painful to manually wrap them all
 per-file-ignores =
     tests/test_relay.py:E501
+    tests/test_schemas.py:E501
     tests/conftest.py:E501


### PR DESCRIPTION
This is a big fedora-messaging thing that wasn't done in the
initial port: we are supposed to define and use message schemas.
This defines two schemas, one for the current message format
*without* BZ4 backwards compatibility and one for the current
message format *with* it. It implements most of the standard
fedora-messaging methods, and some additional methods for
convenience and some with the same names as stock fedmsg_meta
methods (just in case that turns out to be useful). The methods
handle the differences between the backwards-compatible format
and the non-backwards-compatible format as smoothly as possible.

This was based on the bones of the fedmsg_meta processor, but
obviously heavily modified.

Note that there's one fairly significant thing missing here: the
ability to work out FAS user names from Bugzilla email addresses.
This is something that fedmsg_meta provided for us in a module
called fasshim; fedora-messaging does not appear to have an
equivalent yet. Places where we need this are marked FIXME.

Signed-off-by: Adam Williamson <awilliam@redhat.com>