### PR TITLE
Point tox-github-action to the correct branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run tests
-        uses: fedora-python/tox-github-action@master
+        uses: fedora-python/tox-github-action@main
         with:
           tox_env: ${{ matrix.tox_env }}
     strategy:
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run tests
-        uses: fedora-python/tox-github-action@master
+        uses: fedora-python/tox-github-action@main
         with:
           tox_env: ${{ matrix.tox_env }},diff-cover
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Tox-github-action branch is now named main
As seen here: https://github.com/fedora-python/tox-github-action